### PR TITLE
Fix deprecation warning for Symfony 4

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -11,13 +11,13 @@ parameters:
 services:
 
     hades.json_schema.validator:
-        class: %hades.json_schema.validator.service.class%
-        arguments: [%hades.json_schema.validator.class%]
+        class: "%hades.json_schema.validator.service.class%"
+        arguments: ["%hades.json_schema.validator.class%"]
 
     hades.json_schema.uri_resolver:
-        class: %hades.json_schema.uri_resolver.service.class%
-        arguments: [%hades.json_schema.uri_resolver.class%]
+        class: "%hades.json_schema.uri_resolver.service.class%"
+        arguments: ["%hades.json_schema.uri_resolver.class%"]
 
     hades.json_schema.uri_retriever:
-        class: %hades.json_schema.uri_retriever.service.class%
-        arguments: [%hades.json_schema.uri_retriever.class%]
+        class: "%hades.json_schema.uri_retriever.service.class%"
+        arguments: ["%hades.json_schema.uri_retriever.class%"]


### PR DESCRIPTION
Fix for warning: Not quoting the scalar "%hades.json_schema.validator.service.class%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 in "/var/www/public_html/vendor/hadesarchitect/json-schema-bundle/HadesArchitect/JsonSchemaBundle/DependencyInjection/../Resources/config/services.yml"